### PR TITLE
Use find-java-home to find java/javac

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -1,29 +1,34 @@
 var fs = require('fs');
 var spawn = require('child_process').spawn;
-
-var JAVA_HOME = process.env.JAVA_HOME;
+var findJavaHome = require('find-java-home');
 
 var BASE_DIR = __dirname + '/../';
 
 var VALIDATOR = __dirname + '/../support/XMLValidator';
 
-var JAVA = JAVA_HOME + '/bin/java';
-var JAVAC = JAVA_HOME + '/bin/javac';
+var JAVA;
+var JAVAC;
 
 
 function withValidator(callback) {
-  if (!JAVA_HOME) {
-    callback(new Error('JAVA_HOME is not defined'));
-  } else
-  if (!fs.existsSync(JAVAC) && !fs.existsSync(JAVAC + '.exe')) {
-    callback(new Error('JDK required at JAVA_HOME to compile helper'));
-  } else {
-    if (fs.existsSync(VALIDATOR + '.class')) {
-      callback();
+  findJavaHome(function(err, JAVA_HOME) {
+    if (err) {
+      callback(new Error(err));
+    };
+
+    JAVA = JAVA_HOME.trim() + '/bin/java';
+    JAVAC = JAVA_HOME.trim() + '/bin/javac';
+
+    if (!fs.existsSync(JAVAC) && !fs.existsSync(JAVAC + '.exe')) {
+      callback(new Error('JDK required at JAVA_HOME to compile helper'));
     } else {
-      spawn(JAVAC, [ 'support/XMLValidator.java' ], { cwd: BASE_DIR }).on('exit', callback);
+      if (fs.existsSync(VALIDATOR + '.class')) {
+        callback();
+      } else {
+        spawn(JAVAC, [ 'support/XMLValidator.java' ], { cwd: BASE_DIR }).on('exit', callback);
+      }
     }
-  }
+  });
 }
 
 function stripLineEnding(str) {

--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
     "grunt-jasmine-node": "~0.1.0",
     "grunt-release": "^0.7.0",
     "load-grunt-tasks": "~0.3.0"
+  },
+  "dependencies": {
+    "find-java-home": "^0.1.2"
   }
 }


### PR DESCRIPTION
OS X by default does not provide JAVA_HOME variable and there's this fairly useful npm pacakge [find-java-home](https://www.npmjs.com/package/find-java-home) to figure out java home on any platform.

Notice that I have a slight hack in this patch:
```
    JAVA = JAVA_HOME.trim() + '/bin/java';
    JAVAC = JAVA_HOME.trim() + '/bin/javac';
```
trim() is required since find-java-home probably has a bug and returns value with \n in the end.

I'll try to figure out what's wrong with that and maybe submit PR to find-java-home maintainer, but for now, here's this PR for your consideration.