### PR TITLE
Accept a precompiled helper class and correct the classpath delimiter on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 # xsd-schema-validator
 
 
-A fork of (XSD) schema validator for [NodeJS](nodejs.org) that uses [Java](https://www.java.com) to perform the actual validation.  This fork relaxes the original requirement to ensure that `JAVA_HOME` is set and pointed to a JDK.
+(XSD) schema validator for [NodeJS](nodejs.org) that uses [Java](https://www.java.com) to perform the actual validation.
 
 
 ## Prerequisites
 
-Either pre-compile the JAVA support class or ensure a `JAVA_HOME` environment variable exists that points to an installed JDK.  
+A JVM must be installed.  The JVM location must be in the classpath or saved in the `JAVA_HOME` environment variable.  A JDK must be installed to compile the support class. If you would like to precompile the support class run the following command from the application root directory after xsd-schema-validator is installed:
 
-On some platforms, i.e. [Mac OSX](http://www.mkyong.com/java/how-to-set-java_home-environment-variable-on-mac-os-x/) you need to define it manually.
+javac ./node_modules/xsd-schema-validator/support/XMLValidator.java
+
+Note: on some platforms, i.e. [Mac OSX](http://www.mkyong.com/java/how-to-set-java_home-environment-variable-on-mac-os-x/) you need to define `JAVA_HOME` manually.
 
 
 ## How to Use
@@ -16,7 +18,7 @@ On some platforms, i.e. [Mac OSX](http://www.mkyong.com/java/how-to-set-java_hom
 Install via [npm](http://npmjs.org):
 
 ```
-npm install --save alaimo/xsd-schema-validator
+npm install --save xsd-schema-validator
 ```
 
 Use in your application:

--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@
 
 ## Prerequisites
 
-A JVM must be installed.  The JVM location must be in the classpath or saved in the `JAVA_HOME` environment variable.  A JDK must be installed to compile the support class. If you would like to precompile the support class run the following command from the application root directory after xsd-schema-validator is installed:
+A JVM must be installed.  The JVM location must be in the classpath or saved in the `JAVA_HOME` environment variable.  A JDK must be installed to compile the support class. If you would like to precompile the support class run the following command from the application root directory after xsd-schema-validator is installed.
 
+```
 javac ./node_modules/xsd-schema-validator/support/XMLValidator.java
+```
 
 Note: on some platforms, i.e. [Mac OSX](http://www.mkyong.com/java/how-to-set-java_home-environment-variable-on-mac-os-x/) you need to define `JAVA_HOME` manually.
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # xsd-schema-validator
 
 
-A (XSD) schema validator for [NodeJS](nodejs.org) that uses [Java](https://www.java.com) to perform the actual validation.
+A fork of (XSD) schema validator for [NodeJS](nodejs.org) that uses [Java](https://www.java.com) to perform the actual validation.  This fork relaxes the original requirement to ensure that `JAVA_HOME` is set and pointed to a JDK.
 
 
 ## Prerequisites
 
-Ensure a `JAVA_HOME` environment variable exists that points to an installed JDK.
+Either pre-compile the JAVA support class or ensure a `JAVA_HOME` environment variable exists that points to an installed JDK.  
 
 On some platforms, i.e. [Mac OSX](http://www.mkyong.com/java/how-to-set-java_home-environment-variable-on-mac-os-x/) you need to define it manually.
 
@@ -16,7 +16,7 @@ On some platforms, i.e. [Mac OSX](http://www.mkyong.com/java/how-to-set-java_hom
 Install via [npm](http://npmjs.org):
 
 ```
-npm install --save xsd-schema-validator
+npm install --save alaimo/xsd-schema-validator
 ```
 
 Use in your application:

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -1,4 +1,5 @@
 var fs = require('fs');
+var os = require('os');
 var spawn = require('child_process').spawn;
 
 var JAVA_HOME = process.env.JAVA_HOME;
@@ -6,6 +7,9 @@ var JAVA_HOME = process.env.JAVA_HOME;
 var BASE_DIR = __dirname + '/../';
 
 var VALIDATOR = __dirname + '/../support/XMLValidator';
+
+// support windows classpaths
+var CLASSPATH_SEPARATOR = os.platform() === 'win32' ? ';' : ':';
 
 // If JAVA_HOME is not set assume the jvm and/or jdk are in the classpath
 var JAVA = JAVA_HOME ? JAVA_HOME + '/bin/java' : 'java';
@@ -58,7 +62,7 @@ Validator.prototype.validateXML = function(xml, schema, callback) {
       return callback(err);
     }
 
-    var validator = spawn(JAVA, [ '-classpath', [ BASE_DIR, cwd ].join(':'), 'support.XMLValidator', '-stdin', '-schema=' + schema ], { cwd: cwd });
+    var validator = spawn(JAVA, [ '-classpath', [ BASE_DIR, cwd ].join(CLASSPATH_SEPARATOR), 'support.XMLValidator', '-stdin', '-schema=' + schema ], { cwd: cwd });
 
     var result, code, messages = [];
 

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -7,22 +7,20 @@ var BASE_DIR = __dirname + '/../';
 
 var VALIDATOR = __dirname + '/../support/XMLValidator';
 
-var JAVA = JAVA_HOME + '/bin/java';
-var JAVAC = JAVA_HOME + '/bin/javac';
+// If JAVA_HOME is not set assume the jvm and/or jdk are in the classpath
+var JAVA = JAVA_HOME ? JAVA_HOME + '/bin/java' : 'java';
+var JAVAC = JAVA_HOME ? JAVA_HOME + '/bin/javac' : 'javac';
 
 
 function withValidator(callback) {
-  if (!JAVA_HOME) {
-    callback(new Error('JAVA_HOME is not defined'));
-  } else
-  if (!fs.existsSync(JAVAC) && !fs.existsSync(JAVAC + '.exe')) {
+  // If the helper is compiled just use it, otherwise try to build it.  Following this
+  // order will allow for the helper class to be pre-compiled.
+  if(fs.existsSync(VALIDATOR + '.class')) {
+    callback();
+  } else if(JAVA_HOME && !fs.existsSync(JAVAC) && !fs.existsSync(JAVAC + '.exe')) {
     callback(new Error('JDK required at JAVA_HOME to compile helper'));
   } else {
-    if (fs.existsSync(VALIDATOR + '.class')) {
-      callback();
-    } else {
-      spawn(JAVAC, [ 'support/XMLValidator.java' ], { cwd: BASE_DIR }).on('exit', callback);
-    }
+    spawn(JAVAC, [ 'support/XMLValidator.java' ], { cwd: BASE_DIR }).on('exit', callback);
   }
 }
 


### PR DESCRIPTION
This is a useful module. Thank you for spending the time to create it. Unfortunately, many administrators will be hesitant to install a JDK on a production server.  These changes relax the JAVA_HOME and JDK prerequisites.  If the helper class exists the module will just use it regardless of whether or not a JDK is available.  

Also, the delimiter for java classpaths on windows should be a ';' not a ':'.  