### PR TITLE
support international characters in xml values

### DIFF
--- a/support/XMLValidator.java
+++ b/support/XMLValidator.java
@@ -74,7 +74,7 @@ public class XMLValidator implements ErrorHandler {
 
   private static InputStream readFromSysIn() throws IOException {
 
-    BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
+    BufferedReader reader = new BufferedReader(new InputStreamReader(System.in, "UTF-8"));
 
     StringWriter writer = new StringWriter();
 

--- a/test/fixtures/xsd/UmlautTest.xsd
+++ b/test/fixtures/xsd/UmlautTest.xsd
@@ -1,0 +1,11 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <xs:element name="Test" type="Max1LengthText"/>
+    <xs:simpleType name="Max1LengthText">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="1"/>
+            <xs:whiteSpace value="collapse"/>
+            <xs:pattern value="\S+.*"/>
+        </xs:restriction>
+    </xs:simpleType>
+</xs:schema>

--- a/test/spec/validatorSpec.js
+++ b/test/spec/validatorSpec.js
@@ -39,6 +39,19 @@ describe('validator', function() {
   });
 
 
+  it('should work with xml containing umlaut', function(done) {
+
+    var xml = '<?xml version="1.0" encoding="UTF-8"?>' +
+      '<Test>ü</Test>';
+
+
+    validator.validateXML(xml, 'test/fixtures/xsd/UmlautTest.xsd', function(err, result) {
+      expect(result.valid).toBe(true);
+      done();
+    });
+  });
+
+
   it('should validate incorrect xml', function(done) {
 
     var xml = '<?xml version="1.0" encoding="UTF-8"?>' +


### PR DESCRIPTION
**root problem:**
I was having problems with umlaut characters in xm values.
the xsd validator was considering them to be "??".


I reproduced the problem in a test case and found a quick fix.
all that was needed is to read from System.in as UTF-8. 