### PR TITLE
Add explicit support for Buffer.

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -55,7 +55,7 @@ function Validator(options) {
 /**
  * Validate a xml file against the given schema
  *
- * @param {String|ReadableStream|Object} xml
+ * @param {String|Buffer|ReadableStream|Object} xml
  * @param {String} schema path to schema
  * @param {Function} callback to be invoked with (err, result)
  */
@@ -65,6 +65,7 @@ Validator.prototype.validateXML = function(xml, schema, callback) {
       debug = this.debug;
 
   withValidator(function(err) {
+    var validXMLParam = false;
 
     if (err) {
       return callback(err);
@@ -73,6 +74,7 @@ Validator.prototype.validateXML = function(xml, schema, callback) {
     var input = '-stdin';
 
     if (typeof xml === 'object' && xml.file) {
+      validXMLParam = true;
       input = '-file='+ xml.file;
     }
 
@@ -139,6 +141,7 @@ Validator.prototype.validateXML = function(xml, schema, callback) {
 
     // handle readable streams
     if (typeof xml.pipe === 'function') {
+      validXMLParam = true;
 
       xml.on('end', function() {
         xml.unpipe(stdin);
@@ -149,8 +152,18 @@ Validator.prototype.validateXML = function(xml, schema, callback) {
 
     // handle string input
     if (typeof xml === 'string') {
+      validXMLParam = true;
       stdin.write(xml);
       stdin.end();
+    } else if (xml instanceof Buffer) {
+      validXMLParam = true;
+      stdin.write(xml.toString());
+      stdin.end();
+    }
+
+    if (!validXMLParam) {
+      // Return an error if the xml parameter was not one of the supported types.
+      callback(new Error('Unsupported object passed in for xml parameter'));
     }
   });
 };

--- a/test/validator.js
+++ b/test/validator.js
@@ -37,7 +37,7 @@ describe('validator', function() {
                 '</bpmn2:definitions>';
 
       validator.validateXML(xml, BPMN_SCHEMA, function(err, result) {
-        expect(err).toBeDefined();
+        expect(err).toBeTruthy();
 
         // correct error message
         expect(err.message).toMatch(/Attribute 'unknownAttr' is not allowed to appear in element 'bpmn2:definitions'/);
@@ -106,7 +106,42 @@ describe('validator', function() {
       var xmlStream = fs.createReadStream(INVALID_BPMN_FILE, { encoding: 'UTF-8' });
 
       validator.validateXML(xmlStream, BPMN_SCHEMA, function(err, result) {
-        expect(err).toBeDefined();
+        expect(err).toBeTruthy();
+        done();
+      });
+    });
+
+  });
+
+
+  describe('should validate Buffer', function() {
+
+    it('correct', function(done) {
+
+      var buffer = new Buffer('<?xml version="1.0" encoding="UTF-8"?>' +
+                '<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd" id="simple" targetNamespace="http://activiti.org/bpmn">' +
+                '</bpmn2:definitions>');
+
+      validator.validateXML(buffer, BPMN_SCHEMA, function(err, result) {
+
+        if (err) {
+          done(err);
+        } else {
+          expect(result.valid).toBe(true);
+          done();
+        }
+      });
+    });
+
+
+    it('broken', function(done) {
+
+      var buffer = new Buffer('<?xml version="1.0" encoding="UTF-8"?>' +
+                '<bpmn2:definitions unknownAttr="BOOO" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd" id="simple" targetNamespace="http://activiti.org/bpmn">' +
+                '</bpmn2:definitions>');
+
+      validator.validateXML(buffer, BPMN_SCHEMA, function(err, result) {
+        expect(err).toBeTruthy();
         done();
       });
     });
@@ -133,11 +168,22 @@ describe('validator', function() {
     it('broken', function(done) {
 
       validator.validateXML({ file: INVALID_BPMN_FILE }, BPMN_SCHEMA, function(err, result) {
-        expect(err).toBeDefined();
+        expect(err).toBeTruthy();
         done();
       });
     });
 
   });
 
+  describe('should not validate unsupported type for xml', function() {
+
+    it('correct', function(done) {
+
+      validator.validateXML(['this is not valid'], BPMN_SCHEMA, function(err, result) {
+        expect(err).toBeTruthy();
+        done();
+      });
+    });
+
+  });
 });


### PR DESCRIPTION
Also, error out (rather than hang because of no stdin) for unsupported types. 
Also, adjust tests to use toBeTruthy() instead of toBeDefined() so that null is correctly dealt with.

Fixes #12.